### PR TITLE
Parse Query Params From Path in Addition to Method

### DIFF
--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -186,7 +186,7 @@ const getParameterValues = function (param, values) {
  * @param  {Object} parameters Objects described in the document to parse into the query string
  * @param  {Object} values     Optional: query parameter values to use in the snippet if present
  * @return {Object}            Object describing the parameters for a method or path
-*/
+ */
 const parseParametersToQuery = function (openApi, parameters, values) {
   const queryStrings = {};
 
@@ -207,13 +207,10 @@ const parseParametersToQuery = function (openApi, parameters, values) {
         }
       }
     }
-    if (
-      typeof param.in !== 'undefined' &&
-      param.in.toLowerCase() === 'query'
-    ) {
+    if (typeof param.in !== 'undefined' && param.in.toLowerCase() === 'query') {
       // param.name is a safe key, because the spec defines
       // that name MUST be unique
-      queryStrings[param.name] = getParameterValues(param, values)
+      queryStrings[param.name] = getParameterValues(param, values);
     }
   }
 
@@ -241,16 +238,24 @@ const getQueryStrings = function (openApi, path, method, values) {
 
   // First get any parameters from the path
   if (typeof openApi.paths[path].parameters !== 'undefined') {
-    pathQueryStrings = parseParametersToQuery(openApi, openApi.paths[path].parameters, values);
+    pathQueryStrings = parseParametersToQuery(
+      openApi,
+      openApi.paths[path].parameters,
+      values
+    );
   }
 
   if (typeof openApi.paths[path][method].parameters !== 'undefined') {
-    methodQueryStrings = parseParametersToQuery(openApi, openApi.paths[path][method].parameters, values);
+    methodQueryStrings = parseParametersToQuery(
+      openApi,
+      openApi.paths[path][method].parameters,
+      values
+    );
   }
 
   // Merge query strings, with method overriding path
   // from the spec:
-  // If a parameter is already defined at the Path Item, the new definition will override 
+  // If a parameter is already defined at the Path Item, the new definition will override
   // it but can never remove it.
   // https://swagger.io/specification/
   const queryStrings = Object.assign(pathQueryStrings, methodQueryStrings);

--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -153,9 +153,9 @@ const getBaseUrl = function (openApi, path, method) {
 
 /**
  * Gets an object describing the the paremeters (header or query) in a given OpenAPI method
- * @param {Object} param  parameter values to use in snippet
- * @param {Object} values Optional: query parameter values to use in the snippet if present
- * @returns {Object}      Object describing the parameters in a given OpenAPI method
+ * @param  {Object} param  parameter values to use in snippet
+ * @param  {Object} values Optional: query parameter values to use in the snippet if present
+ * @return {Object}      Object describing the parameters in a given OpenAPI method
  */
 const getParameterValues = function (param, values) {
   let value =
@@ -182,8 +182,8 @@ const getParameterValues = function (param, values) {
 /**
  * Parse parameter object into query string objects
  *
- * @param {Object} openApi    OpenApi document
- * @param {Object} parameters Objects described in the document to parse into the query string
+ * @param  {Object} openApi    OpenApi document
+ * @param  {Object} parameters Objects described in the document to parse into the query string
  * @param  {Object} values    Optional: query parameter values to use in the snippet if present
  * @return {array}            List of objects describing the query strings
 */

--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -182,9 +182,10 @@ const getParameterValues = function (param, values) {
 /**
  * Parse parameter object into query string objects
  *
- * @param {Object} openApi OpenApi document
- * @param {Object} parameters Objects described in the document to parse into the query string 
- * @param  {Object} values  Optional: query parameter values to use in the snippet if present
+ * @param {Object} openApi    OpenApi document
+ * @param {Object} parameters Objects described in the document to parse into the query string
+ * @param  {Object} values    Optional: query parameter values to use in the snippet if present
+ * @return {array}            List of objects describing the query strings
 */
 const parseParametersToQuery = function (openApi, parameters, values) {
   const queryStrings = [];
@@ -213,7 +214,7 @@ const parseParametersToQuery = function (openApi, parameters, values) {
       queryStrings.push(getParameterValues(param, values));
     }
   }
-  
+
   return queryStrings;
 };
 

--- a/test/parameter_example_swagger.json
+++ b/test/parameter_example_swagger.json
@@ -75,6 +75,61 @@
           }
         }
       }
+    },
+    "/animals": {
+      "parameters": [
+        {
+          "name": "tags",
+          "in": "query",
+          "description": "tags to filter by",
+          "required": false,
+          "style": "form",
+          "example": ["dog", "cat"],
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "name": "limit",
+          "in": "query",
+          "description": "maximum number of results to return",
+          "example": 10,
+          "required": false,
+          "schema": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      ],
+      "get": {
+        "description": "Get Pets from store",
+        "operationId": "getPet",
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/test/parameter_example_swagger.json
+++ b/test/parameter_example_swagger.json
@@ -130,6 +130,61 @@
           }
         }
       }
+    },
+    "/species": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "query",
+          "description": "the species id",
+          "required": false,
+          "example": 1, 
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ],
+      "get": {
+        "description": "Get Pets from store",
+        "operationId": "getPet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "description": "A comma-seperated list of species IDs",
+            "required": false,
+            "example": [1, 2],
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Species"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -158,6 +213,20 @@
           },
           "tag": {
             "type": "string"
+          }
+        }
+      },
+      "Species": {
+        "items": {
+          "$ref": "#/components/thing"
+        },
+        "type": "array"
+      },
+      "Thing": {
+        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "integer"
           }
         }
       },

--- a/test/parameter_example_swagger.json
+++ b/test/parameter_example_swagger.json
@@ -138,7 +138,7 @@
           "in": "query",
           "description": "the species id",
           "required": false,
-          "example": 1, 
+          "example": 1,
           "schema": {
             "type": "integer"
           }

--- a/test/test.js
+++ b/test/test.js
@@ -196,3 +196,16 @@ test('Testing the case when an example is provided, use the provided example val
   t.false(/SOME_INTEGER_VALUE/.test(snippet));
   t.end();
 });
+
+test('Query Params Defined for all methods should be resolved', function (t) {
+  const result = OpenAPISnippets.getEndpointSnippets(
+    ParameterExampleReferenceAPI,
+    '/animals',
+    'get',
+    ['node_request']
+  );
+  const snippet = result.snippets[0].content;
+  t.true(/ {tags: 'dog,cat', limit: '10'}/.test(snippet));
+  t.false(/SOME_INTEGER_VALUE/.test(snippet));
+  t.end();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -209,3 +209,27 @@ test('Query Params Defined for all methods should be resolved', function (t) {
   t.false(/SOME_INTEGER_VALUE/.test(snippet));
   t.end();
 });
+
+test('Query Params Defined for all methods are overriden by method definitions', function (t) {
+  const result = OpenAPISnippets.getEndpointSnippets(
+    ParameterExampleReferenceAPI,
+    '/species',
+    'get',
+    ['node_request']
+  );
+  const snippet = result.snippets[0].content;
+  t.true(/ qs: {id: '1,2'}/.test(snippet));
+  t.end();
+});
+
+test('Snippet for Get with no parameters should work', function (t) {
+  const result = OpenAPISnippets.getEndpointSnippets(
+    InstagramOpenAPI,
+    '/media/popular',
+    'get',
+    ['node_request']
+  );
+  const snippet = result.snippets[0].content;
+  t.false(/qs/.test(snippet));
+  t.end();
+})

--- a/test/test.js
+++ b/test/test.js
@@ -232,4 +232,4 @@ test('Snippet for Get with no parameters should work', function (t) {
   const snippet = result.snippets[0].content;
   t.false(/qs/.test(snippet));
   t.end();
-})
+});


### PR DESCRIPTION
Parse any query params that are defined on the path object in addition to parsing them on the method.

## Included
- Parse query params that are included on the path instead of just the method. This allows code snippets to include any params that are required for all methods on a path.
- Small refactor to reduce duplicate code required to parse parameters on the method and the path.
- Test to verify that the new behavior works correctly and the snippet generated contains the correct information.

Want to get any feedback on improving this code before I submit it to the official library