### PR TITLE
Generate Snippets for Multiple Content-Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ For example:
     "snippets": [
       {
         "id": "node",
+        "mimeType": "application/json",  // Only set for methods with a request body
         "title": "Node + Native",
         "content": "var http = require(\"https\");\n\nvar options = {..."
       }

--- a/index.js
+++ b/index.js
@@ -33,7 +33,13 @@ const getEndpointSnippets = function (openApi, path, method, targets, values) {
   const snippets = [];
   for (const har of hars) {
     const snippet = new HTTPSnippet(har);
-    snippets.push(...getSnippetsForTargets(targets, snippet, (har.comment ? har.comment : undefined)));
+    snippets.push(
+      ...getSnippetsForTargets(
+        targets,
+        snippet,
+        har.comment ? har.comment : undefined
+      )
+    );
   }
 
   // use first element since method, url, and description
@@ -182,16 +188,16 @@ const formatTarget = function (targetStr) {
  *
  * @param targets {array}               List of language targets to generate code for
  * @param snippet {Object}              Snippet object from httpsnippet to convert into the target objects
- * @param mimeType {string | undefined} Additional information to add uniqueness to the produced snippets  
+ * @param mimeType {string | undefined} Additional information to add uniqueness to the produced snippets
  */
-const getSnippetsForTargets = function(targets, snippet, mimeType) {
+const getSnippetsForTargets = function (targets, snippet, mimeType) {
   const snippets = [];
   for (let j in targets) {
     const target = formatTarget(targets[j]);
     if (!target) throw new Error('Invalid target: ' + targets[j]);
     snippets.push({
       id: targets[j],
-      ...(mimeType !== undefined && {mimeType: mimeType}), 
+      ...(mimeType !== undefined && { mimeType: mimeType }),
       title: target.title,
       content: snippet.convert(
         target.language,
@@ -199,7 +205,7 @@ const getSnippetsForTargets = function(targets, snippet, mimeType) {
       ),
     });
   }
-  return snippets 
+  return snippets;
 };
 
 const capitalizeFirstLetter = function (string) {

--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -104,21 +104,43 @@ const getPayload = function (openApi, path, method) {
   }
 
   if (
-    openApi.paths[path][method].requestBody &&
-    openApi.paths[path][method].requestBody.content &&
-    openApi.paths[path][method].requestBody.content['application/json'] &&
-    openApi.paths[path][method].requestBody.content['application/json'].schema
-  ) {
-    const sample = OpenAPISampler.sample(
-      openApi.paths[path][method].requestBody.content['application/json']
-        .schema,
-      { skipReadOnly: true },
-      openApi
-    );
-    return {
-      mimeType: 'application/json',
-      text: JSON.stringify(sample),
-    };
+     openApi.paths[path][method].requestBody &&
+     openApi.paths[path][method].requestBody.content
+   ) {
+     if (openApi.paths[path][method].requestBody.content['application/json'] &&
+       openApi.paths[path][method].requestBody.content['application/json'].schema
+     ) {
+       const sample = OpenAPISampler.sample(
+         openApi.paths[path][method].requestBody.content['application/json']
+           .schema,
+         { skipReadOnly: true },
+         openApi
+       );
+       return {
+         mimeType: 'application/json',
+         text: JSON.stringify(sample)
+       };
+     }
+
+     if (openApi.paths[path][method].requestBody.content['multipart/form-data'] &&
+       openApi.paths[path][method].requestBody.content['multipart/form-data'].schema
+     ) {
+       const sample = OpenAPISampler.sample(openApi.paths[path][method].requestBody.content['multipart/form-data']
+           .schema,
+         {skipReadOnly: true},
+         openApi
+       );
+
+       if (sample === undefined) return null;
+
+       const params = [];
+       Object.keys(sample).map(key => params.push({'name': key, 'value': sample[key]}));
+
+       return {
+         mimeType: 'multipart/form-data',
+         params: params,
+       };
+     }
   }
   return null;
 };

--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -61,7 +61,7 @@ const createHar = function (openApi, path, method, queryParamValues) {
       const copiedHar = JSON.parse(JSON.stringify(baseHar));
       copiedHar.postData = postData;
       copiedHar.comment = postData.mimeType;
-			copiedHar.headers.push({name: 'content-type', value: postData.mimeType});
+      copiedHar.headers.push({name: 'content-type', value: postData.mimeType});
       hars.push(copiedHar);
     }
   } else {
@@ -123,32 +123,31 @@ const getPayloads = function (openApi, path, method) {
     openApi.paths[path][method].requestBody &&
     openApi.paths[path][method].requestBody.content
   ) {
-		['application/json', 'multipart/form-data'].forEach((type) => {
-		  const content = openApi.paths[path][method].requestBody.content[type]
-		  if (content && content.schema) {
-		    const sample = OpenAPISampler.sample(
-		      content.schema,
-		      { skipReadOnly: true },
-		      openApi
-		    );
-		    if (type === 'application/json') {
-		      payloads.push({
-		        mimeType: type,
-		        text: JSON.stringify(sample)
-		      });
-		    } else if (type === 'multipart/form-data') {
-		      let params = [];
-		      if (sample !== undefined) {
-		        Object.keys(sample).forEach(key => params.push({'name': key, 'value': sample[key]}));
-		      	payloads.push({
-		      	  mimeType: type,
-		      	  params: params
-		      	});
-		      }
-		    }
-		  }
-		});
-	}
+    ['application/json', 'multipart/form-data'].forEach((type) => {
+      const content = openApi.paths[path][method].requestBody.content[type]
+      if (content && content.schema) {
+        const sample = OpenAPISampler.sample(
+          content.schema,
+          { skipReadOnly: true },
+          openApi
+        );
+        if (type === 'application/json') {
+          payloads.push({
+            mimeType: type,
+            text: JSON.stringify(sample)
+          });
+        } else if (type === 'multipart/form-data') {
+          if (sample !== undefined) {
+            const params = Object.keys(sample).reduce((acc,key)=>acc.concat([{'name': key, 'value': sample[key]}]),[]);
+            payloads.push({
+              mimeType: type,
+              params: params
+            });
+          }
+        }
+      }
+    });
+  }
   return payloads;
 };
 

--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -134,7 +134,7 @@ const getPayload = function (openApi, path, method) {
        if (sample === undefined) return null;
 
        const params = [];
-       Object.keys(sample).map(key => params.push({'name': key, 'value': sample[key]}));
+        Object.keys(sample).forEach(key => params.push({'name': key, 'value': sample[key]}));
 
        return {
          mimeType: 'multipart/form-data',

--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -147,7 +147,7 @@ const getPayloads = function (openApi, path, method) {
           Object.keys(sample).map(key => params.push({'name': key, 'value': sample[key]}));
 
           payloads.push({
-            mimeType: 'multipart/form-data',
+            mimeType: contentType, 
             params: params,
           });
         }

--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -106,41 +106,41 @@ const getPayload = function (openApi, path, method) {
   if (
      openApi.paths[path][method].requestBody &&
      openApi.paths[path][method].requestBody.content
-   ) {
-     if (openApi.paths[path][method].requestBody.content['application/json'] &&
-       openApi.paths[path][method].requestBody.content['application/json'].schema
-     ) {
-       const sample = OpenAPISampler.sample(
-         openApi.paths[path][method].requestBody.content['application/json']
-           .schema,
-         { skipReadOnly: true },
-         openApi
-       );
-       return {
-         mimeType: 'application/json',
-         text: JSON.stringify(sample)
-       };
-     }
-
-     if (openApi.paths[path][method].requestBody.content['multipart/form-data'] &&
-       openApi.paths[path][method].requestBody.content['multipart/form-data'].schema
-     ) {
-       const sample = OpenAPISampler.sample(openApi.paths[path][method].requestBody.content['multipart/form-data']
-           .schema,
-         {skipReadOnly: true},
-         openApi
-       );
-
-       if (sample === undefined) return null;
-
-       const params = [];
-        Object.keys(sample).forEach(key => params.push({'name': key, 'value': sample[key]}));
-
-       return {
-         mimeType: 'multipart/form-data',
-         params: params,
-       };
-     }
+  ) {
+    if (openApi.paths[path][method].requestBody.content['application/json'] &&
+      openApi.paths[path][method].requestBody.content['application/json'].schema
+    ) {
+      const sample = OpenAPISampler.sample(
+        openApi.paths[path][method].requestBody.content['application/json']
+          .schema,
+        { skipReadOnly: true },
+        openApi
+      );
+      return {
+        mimeType: 'application/json',
+        text: JSON.stringify(sample)
+      };
+    }
+    
+    if (openApi.paths[path][method].requestBody.content['multipart/form-data'] &&
+      openApi.paths[path][method].requestBody.content['multipart/form-data'].schema
+    ) {
+      const sample = OpenAPISampler.sample(
+        openApi.paths[path][method].requestBody.content['multipart/form-data'].schema,
+        {skipReadOnly: true},
+        openApi
+      );
+    
+      if (sample === undefined) return null;
+    
+      const params = [];
+      Object.keys(sample).forEach(key => params.push({'name': key, 'value': sample[key]}));
+    
+      return {
+        mimeType: 'multipart/form-data',
+        params: params,
+      };
+    }
   }
   return null;
 };

--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -61,11 +61,14 @@ const createHar = function (openApi, path, method, queryParamValues) {
       const copiedHar = JSON.parse(JSON.stringify(baseHar));
       copiedHar.postData = postData;
       copiedHar.comment = postData.mimeType;
-      copiedHar.headers.push({name: 'content-type', value: postData.mimeType});
+      copiedHar.headers.push({
+        name: 'content-type',
+        value: postData.mimeType,
+      });
       hars.push(copiedHar);
     }
   } else {
-    hars = [baseHar]
+    hars = [baseHar];
   }
 
   return hars;
@@ -96,10 +99,12 @@ const getPayloads = function (openApi, path, method) {
             { skipReadOnly: true },
             openApi
           );
-          return [{
-            mimeType: 'application/json',
-            text: JSON.stringify(sample),
-          }];
+          return [
+            {
+              mimeType: 'application/json',
+              text: JSON.stringify(sample),
+            },
+          ];
         } catch (err) {
           console.log(err);
           return null;
@@ -124,7 +129,7 @@ const getPayloads = function (openApi, path, method) {
     openApi.paths[path][method].requestBody.content
   ) {
     ['application/json', 'multipart/form-data'].forEach((type) => {
-      const content = openApi.paths[path][method].requestBody.content[type]
+      const content = openApi.paths[path][method].requestBody.content[type];
       if (content && content.schema) {
         const sample = OpenAPISampler.sample(
           content.schema,
@@ -134,14 +139,17 @@ const getPayloads = function (openApi, path, method) {
         if (type === 'application/json') {
           payloads.push({
             mimeType: type,
-            text: JSON.stringify(sample)
+            text: JSON.stringify(sample),
           });
         } else if (type === 'multipart/form-data') {
           if (sample !== undefined) {
-            const params = Object.keys(sample).reduce((acc,key)=>acc.concat([{'name': key, 'value': sample[key]}]),[]);
+            const params = Object.keys(sample).reduce(
+              (acc, key) => acc.concat([{ name: key, value: sample[key] }]),
+              []
+            );
             payloads.push({
               mimeType: type,
-              params: params
+              params: params,
             });
           }
         }

--- a/test/form_data_example.json
+++ b/test/form_data_example.json
@@ -1,0 +1,76 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team",
+      "email": "apiteam@swagger.io",
+      "url": "http://swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/api"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "patch": {
+        "description": "Creates a new pet in the store.  Duplicates are allowed",
+        "operationId": "addPet",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/ModifyPet"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ModifyPet": {
+        "properties": {
+          "pet[name]": {
+            "type": "string"
+          },
+          "pet[tag]": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/multiple_request_content.json
+++ b/test/multiple_request_content.json
@@ -1,0 +1,94 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team",
+      "email": "apiteam@swagger.io",
+      "url": "http://swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/api"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "patch": {
+        "description": "Creates a new pet in the store.  Duplicates are allowed",
+        "operationId": "addPet",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ModifyPet"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/ModifyPetFile"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ModifyPetFile": {
+        "properties": {
+          "pet[name]": {
+            "type": "string"
+          },
+          "pet[tag]": {
+            "type": "string"
+          },
+          "pet[picture]": {
+            "type": "string"
+          }
+        }
+      },
+      "ModifyPet": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -208,7 +208,9 @@ test('Generate snippet with multipart/form-data', function (t) {
   );
   const snippet = result.snippets[0].content;
   t.true(/boundary=---011000010111000001101001/.test(snippet));
-  t.true(/formData: {'pet\[name\]': 'string', 'pet\[tag\]': 'string'}/.test(snippet));
+  t.true(
+    /formData: {'pet\[name\]': 'string', 'pet\[tag\]': 'string'}/.test(snippet)
+  );
   t.end();
 });
 
@@ -220,14 +222,24 @@ test('Generate snippets with multiple content types', function (t) {
     ['node_request']
   );
   t.equal(result.snippets.length, 2);
-	for (const snippet of result.snippets) {
-		if (snippet.mimeType === 'application/json') {
-			t.true(/headers: {'content-type': 'application\/json'}/.test(snippet.content));
-			t.true(/body: {name: 'string', tag: 'string'}/.test(snippet.content));
-		} else if (snippet.mimeType === 'multipart/form-data') {
-			t.true(/headers: {'content-type': 'multipart\/form-data; boundary=---011000010111000001101001'}/.test(snippet.content));
-  		t.true(/formData: {'pet\[name\]': 'string', 'pet\[tag\]': 'string', 'pet\[picture\]': 'string'}/.test(snippet.content));
-		}
-	}
+  for (const snippet of result.snippets) {
+    if (snippet.mimeType === 'application/json') {
+      t.true(
+        /headers: {'content-type': 'application\/json'}/.test(snippet.content)
+      );
+      t.true(/body: {name: 'string', tag: 'string'}/.test(snippet.content));
+    } else if (snippet.mimeType === 'multipart/form-data') {
+      t.true(
+        /headers: {'content-type': 'multipart\/form-data; boundary=---011000010111000001101001'}/.test(
+          snippet.content
+        )
+      );
+      t.true(
+        /formData: {'pet\[name\]': 'string', 'pet\[tag\]': 'string', 'pet\[picture\]': 'string'}/.test(
+          snippet.content
+        )
+      );
+    }
+  }
   t.end();
-})
+});

--- a/test/test.js
+++ b/test/test.js
@@ -13,6 +13,7 @@ const PetStoreOpenAPI3 = require('./petstore_oas.json');
 const ParameterSchemaReferenceAPI = require('./parameter_schema_reference');
 const ParameterExampleReferenceAPI = require('./parameter_example_swagger.json');
 const FormDataExampleReferenceAPI = require('./form_data_example.json');
+const MultipleRequestContentReferenceAPI = require('./multiple_request_content.json');
 
 test('Getting snippets should not result in error or undefined', function (t) {
   t.plan(1);
@@ -210,3 +211,23 @@ test('Generate snippet with multipart/form-data', function (t) {
   t.true(/formData: {'pet\[name\]': 'string', 'pet\[tag\]': 'string'}/.test(snippet));
   t.end();
 });
+
+test('Generate snippets with multiple content types', function (t) {
+  const result = OpenAPISnippets.getEndpointSnippets(
+    MultipleRequestContentReferenceAPI,
+    '/pets',
+    'patch',
+    ['node_request']
+  );
+  t.equal(result.snippets.length, 2);
+	for (const snippet of result.snippets) {
+		if (snippet.mimeType === 'application/json') {
+			t.true(/headers: {'content-type': 'application\/json'}/.test(snippet.content));
+			t.true(/body: {name: 'string', tag: 'string'}/.test(snippet.content));
+		} else if (snippet.mimeType === 'multipart/form-data') {
+			t.true(/headers: {'content-type': 'multipart\/form-data; boundary=---011000010111000001101001'}/.test(snippet.content));
+  		t.true(/formData: {'pet\[name\]': 'string', 'pet\[tag\]': 'string', 'pet\[picture\]': 'string'}/.test(snippet.content));
+		}
+	}
+  t.end();
+})

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,7 @@ const PetStoreOpenAPI = require('./petstore_swagger.json');
 const PetStoreOpenAPI3 = require('./petstore_oas.json');
 const ParameterSchemaReferenceAPI = require('./parameter_schema_reference');
 const ParameterExampleReferenceAPI = require('./parameter_example_swagger.json');
+const FormDataExampleReferenceAPI = require('./form_data_example.json');
 
 test('Getting snippets should not result in error or undefined', function (t) {
   t.plan(1);
@@ -194,5 +195,18 @@ test('Testing the case when an example is provided, use the provided example val
   const snippet = result.snippets[0].content;
   t.true(/ {tags: 'dog,cat', limit: '10'}/.test(snippet));
   t.false(/SOME_INTEGER_VALUE/.test(snippet));
+  t.end();
+});
+
+test('Generate snippet with multipart/form-data', function (t) {
+  const result = OpenAPISnippets.getEndpointSnippets(
+    FormDataExampleReferenceAPI,
+    '/pets',
+    'patch',
+    ['node_request']
+  );
+  const snippet = result.snippets[0].content;
+  t.true(/boundary=---011000010111000001101001/.test(snippet));
+  t.true(/formData: {'pet\[name\]': 'string', 'pet\[tag\]': 'string'}/.test(snippet));
   t.end();
 });


### PR DESCRIPTION
Adds support for generating snippets for endpoint methods that support multiple content-types. Endpoints might support uploading files using `multipart/form-data`, but otherwise support `application/json` for other modifications. As it stands this library has the following behavior:

- Generate a snippet for the first content-type defined in `path.method.requestBody.content`
- Set the `content-type` header to be the last content-type defined in `path.method.requestbody.content`

This PR address those concerns by:
- Generating a code snippet for each of the content-types defined in `path.method.requestBody.content`
- Adding `mimeType` to the snippet object to provide uniqueness of snippets
- Removing the parsing of `content-type` headers in `getHeaders.
- Setting `content-type` headers for HARs that have postData
- Simplify `getPayloads` to loop over supported `content-type`s instead of hard coding blocks. This will ease support for more `content-type` support in the future

NOTE: this is built off of the multipart/form-data PR.

Want to get any feedback on improving this code before I submit it to the official library
